### PR TITLE
Update contributor name | Nguyễn Ngọc Hiền to DancyCat

### DIFF
--- a/src/contributors.json
+++ b/src/contributors.json
@@ -14,7 +14,7 @@
     "MrMystt",
     "NTT-2k5",
     "Nanashi.",
-    "Nguyễn Ngọc Hiền",
+    "DancyCat",
     "Sam Night",
     "Seanoo1",
     "Soniapple",


### PR DESCRIPTION
I'd like to change the contributor name from Nguyễn Ngọc Hiền to DancyCat, since the current one doesn't fit well in Sonolus's Credits section.